### PR TITLE
Change structure of language to fit new language grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 a.out
 compiler
 *.swp
+.ycm_extra_conf.*
+tags

--- a/base.c
+++ b/base.c
@@ -62,8 +62,9 @@ void matchString(char* s) {
 }
 
 int isSpecificString(char *s){
-  return strcmp(s,VALUE);
+  return strcmp(s,VALUE) == 0;
 }
+
 void matchString2(char* s) {
   if(strcmp(s, VALUE) != 0) {
       expected(s);
@@ -185,6 +186,7 @@ void error(char* s) {
 }
 
 void expected(char* s) {
+  if(*s == '\n') s = "endline";
   sprintf(tmp, "EXPECTED '%s'" , s);
   error(tmp);
 }

--- a/base.c
+++ b/base.c
@@ -61,6 +61,9 @@ void matchString(char* s) {
   }
 }
 
+int isSpecificString(char *s){
+  return strcmp(s,VALUE);
+}
 void matchString2(char* s) {
   if(strcmp(s, VALUE) != 0) {
       expected(s);
@@ -140,7 +143,7 @@ void getNum() {
 }
 
 void handleWhite() {
-  while(look == ' ' || look == '\r' || look == '\t') { 
+  while(look == ' ' || look == '\r' || look == '\t') {
 	  getChar();
   }
 }
@@ -148,7 +151,7 @@ void next() {
   handleWhite();
   if(isAlpha(look)) {
     getName();
-    
+
   }
   else if(isNum(look) || look == '-' || look == '.') {
     getNum();

--- a/compiler.h
+++ b/compiler.h
@@ -17,36 +17,36 @@
 #define DOUBLE_SZ 8
 
 enum TOKENS {
-  CHAR_TYPE,
-  INT_TYPE,
-  FLOAT_TYPE,
-  DOUBLE_TYPE,
-  IF,
-  ELSE,
-  FOR,
-  WHILE,
-  LEFT_PAREN,
-  RIGHT_PAREN,
-  ADD,
-  SUB,
-  MUL,
-  DIV,
-  LESS,
-  LESS_EQUAL,
-  GREATER,
-  GREATER_EQUAL,
-  EQUAL,
-  LEFT_BRACE,
-  RIGHT_BRACE,
-  LEFT_BRACKET,
-  RIGHT_BRACKET,
-  ASSIGN,
-  SEMI_COLON,
-  ENDLINE,
-  NAME,
-  SYMBOL,
-  NUMBER,
-  DECIMAL
+  CHAR_TYPE,    // 0
+  INT_TYPE,     // 1
+  FLOAT_TYPE,   // 2
+  DOUBLE_TYPE,  // 3
+  IF,           // 4
+  ELSE,         // 5
+  FOR,          // 6
+  WHILE,        // 7
+  LEFT_PAREN,   // 8
+  RIGHT_PAREN,  // 9
+  ADD,          // 10
+  SUB,          // 11
+  MUL,          // 12
+  DIV,          // 13
+  LESS,         // 14
+  LESS_EQUAL,   // 15
+  GREATER,      // 16
+  GREATER_EQUAL,// 17
+  EQUAL,        // 18
+  LEFT_BRACE,   // 19
+  RIGHT_BRACE,  // 20
+  LEFT_BRACKET, // 21
+  RIGHT_BRACKET,// 22
+  ASSIGN,       // 23
+  SEMI_COLON,   // 24
+  ENDLINE,      // 25
+  NAME,         // 26
+  SYMBOL,       // 27
+  NUMBER,       // 28
+  DECIMAL       // 29
 };
 
 extern char* str_tokens[];

--- a/compiler.h
+++ b/compiler.h
@@ -59,6 +59,7 @@ void nextString();
 void init();
 void scan();
 void matchString();
+int isSpecificString(char *s);
 void matchString2();
 void error(char *s);
 void expected(char* s);

--- a/main.c
+++ b/main.c
@@ -49,9 +49,8 @@ void DoArrayDeclaration(enum TOKENS type) {
     default:
       break;
   }
-
-
 }
+
 void DoVariableDeclaration(enum TOKENS type) {
   switch(type) {
     case CHAR_TYPE:
@@ -89,7 +88,6 @@ void DoAssignment() {
 
 }
 void Statement() {
-  next();
   if(isDeclaration(TOKEN)) {
     DoDeclaration();
   }
@@ -107,10 +105,22 @@ void CodeLine() {
     next();
   } while(TOKEN == SEMI_COLON);
   matchString("\n");
+  next();
 }
 
 void CodeBlock() {
-  while(look != EOF) CodeLine();
+  next();
+  matchString("{");
+  next();
+  while(TOKEN != RIGHT_BRACE){
+    if(isSpecificString("\n")){
+      CodeLine();
+    }
+    else{
+      matchString("\n");
+      next();
+    }
+  }
 }
 
 void Language() {

--- a/main.c
+++ b/main.c
@@ -97,15 +97,21 @@ void Statement() {
   else {
     error("unrecognized statement");
   }
+  next();
 }
 
 void CodeLine() {
-  do {
-    Statement();
+  if(TOKEN == ENDLINE) {
     next();
-  } while(TOKEN == SEMI_COLON);
-  matchString("\n");
-  next();
+  }
+  else {
+    Statement();
+  while(TOKEN == SEMI_COLON) {
+    next();
+    Statement();
+  }
+   matchString("\n");
+  }
 }
 
 void CodeBlock() {
@@ -113,14 +119,9 @@ void CodeBlock() {
   matchString("{");
   next();
   while(TOKEN != RIGHT_BRACE){
-    if(isSpecificString("\n")){
-      CodeLine();
-    }
-    else{
-      matchString("\n");
-      next();
-    }
+    CodeLine();
   }
+  matchString("}");
 }
 
 void Language() {

--- a/test
+++ b/test
@@ -1,0 +1,6 @@
+{
+int [10] a; char b ;double c 
+float d; float wtf
+float [100] ef
+char[12]lld double [0] ok
+}


### PR DESCRIPTION
CodeBlock now requires you to start with { and end with }
Removed the necessity of an end of file for the language
fixed the enter problem
